### PR TITLE
add gzip + url_root options

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ In your Rails applications environment configuration:
 
 If you need to pass options to uglifier:
 
-    config.assets.uglifier = {output: {beautify: true, indent_level: 2}, compress: {angular: true}} 
+    config.assets.uglifier = {output: {beautify: true, indent_level: 2}, compress: {angular: true}}
 
 Your assets will be built as normal, also maps and concatenated sources will be provided as well in `public/assets/maps` and `public/assets/sources`.
 These subdirs may be configured:
@@ -41,6 +41,10 @@ These subdirs may be configured:
     config.assets.sourcemaps_prefix = 'my_maps'
     config.assets.uncompressed_prefix = 'my_sources'
 
+You can optionally gzip your maps and sources as well (since these files live outside of the assets pipeline this won't happen automatically):
+
+    config.assets.sourcemaps_gzip = true
+    config.assets.uncompressed_gzip = true
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,17 @@ These subdirs may be configured:
 You can optionally gzip your maps and sources as well (since these files live outside of the assets pipeline this won't happen automatically):
 
     config.assets.sourcemaps_gzip = true
-    config.assets.uncompressed_gzip = true
+
+By default maps and sources are defined relatively and will be fetched from the same domain your js file is served from. If you are using a CDN you may not want this - instead you might want to use a direct link to your site so you can more easily implement IP or Basic Auth protection:
+
+    # set to a url - js will be served from 'http://cdn.host.com' but source map links will use 'http://some.host.com/'
+
+    config.assets.sourcemaps_url_root = 'http://some.host.com/'
+
+If you use CloudFront you might want to generate a signed url for these files that limits access based on IP address. You can do that by setting sourcemaps_url_root to a Proc and handling your URL signing there:
+
+    # using a Proc - see the AWS SDK docs for everything required to make this work
+    config.assets.sourcemaps_url_root = Proc.new { |file| MyApp.generate_a_signed_url_for file }
 
 ## Example
 

--- a/lib/sprockets_uglifier_with_source_maps/compressor.rb
+++ b/lib/sprockets_uglifier_with_source_maps/compressor.rb
@@ -20,6 +20,18 @@ module SprocketsUglifierWithSM
       File.open(sourcemap_path, 'w') { |f| f.write sourcemap }
       File.open(uncompressed_path, 'w') { |f| f.write data }
 
+      to_gzip = []
+      (to_gzip << sourcemap_path) if Rails.application.config.assets.sourcemaps_gzip
+      (to_gzip << uncompressed_path) if Rails.application.config.assets.uncompressed_gzip
+
+      to_gzip.each do |f|
+        Zlib::GzipWriter.open("#{f}.gz") do |gz|
+          gz.mtime = File.mtime(f)
+          gz.orig_name = f
+          gz.write IO.binread(f)
+        end
+      end
+
       compressed_data.concat "\n//# sourceMappingURL=#{sourcemap_filename}\n"
     end
 

--- a/lib/sprockets_uglifier_with_source_maps/railtie.rb
+++ b/lib/sprockets_uglifier_with_source_maps/railtie.rb
@@ -8,7 +8,7 @@ module SprocketsUglifierWithSM
       config.assets.sourcemaps_prefix ||= 'maps'
       config.assets.uncompressed_prefix ||= 'sources'
       config.assets.sourcemaps_gzip ||= false
-      config.assets.uncompressed_gzip ||= false
+      config.assets.sourcemaps_url_root ||= false
     end
   end
 end

--- a/lib/sprockets_uglifier_with_source_maps/railtie.rb
+++ b/lib/sprockets_uglifier_with_source_maps/railtie.rb
@@ -7,6 +7,8 @@ module SprocketsUglifierWithSM
       config = app.config
       config.assets.sourcemaps_prefix ||= 'maps'
       config.assets.uncompressed_prefix ||= 'sources'
+      config.assets.sourcemaps_gzip ||= false
+      config.assets.uncompressed_gzip ||= false
     end
   end
 end


### PR DESCRIPTION
1) add gzip functionality - since these files are outside of the assets pipeline there's not an easy way to get the compressed automatically.

2) add url_root option - our js is served through a cdn but we didn't want our source maps available there so i added a mechanism to change the url used for source + map files. 

