### PR TITLE
use sprockets3-style compressor interface

### DIFF
--- a/lib/sprockets_uglifier_with_source_maps.rb
+++ b/lib/sprockets_uglifier_with_source_maps.rb
@@ -1,6 +1,5 @@
 require 'sprockets_uglifier_with_source_maps/version'
 require 'sprockets'
-require 'uglifier'
 require 'sprockets_uglifier_with_source_maps/compressor'
 Sprockets.register_compressor 'application/javascript', :uglifier_with_source_maps, SprocketsUglifierWithSM::Compressor
 Sprockets.register_compressor 'application/javascript', :uglify_with_source_maps, SprocketsUglifierWithSM::Compressor

--- a/lib/sprockets_uglifier_with_source_maps/railtie.rb
+++ b/lib/sprockets_uglifier_with_source_maps/railtie.rb
@@ -3,7 +3,7 @@ require 'action_controller/railtie'
 module SprocketsUglifierWithSM
   class Railtie < ::Rails::Railtie
 
-    initializer 'sprockets-uglifier-with-source-maps.environment', after: 'sprockets.environment', group: :all do |app|
+    initializer 'sprockets-uglifier-with-source-maps.environment', group: :all do |app|
       config = app.config
       config.assets.sourcemaps_prefix ||= 'maps'
       config.assets.uncompressed_prefix ||= 'sources'

--- a/lib/sprockets_uglifier_with_source_maps/version.rb
+++ b/lib/sprockets_uglifier_with_source_maps/version.rb
@@ -1,3 +1,3 @@
 module SprocketsUglifierWithSM
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end

--- a/sprockets_uglifier_with_source_maps.gemspec
+++ b/sprockets_uglifier_with_source_maps.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'sprockets-rails', '>= 3.0.0.beta1'
-  spec.add_runtime_dependency 'uglifier', '>= 2.5'
+  spec.add_runtime_dependency 'sprockets-rails', '~> 3.0'
+  spec.add_runtime_dependency 'uglifier', '~> 2.5'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
 end


### PR DESCRIPTION
after some reason sprockets-3x version the old tilt-style compressor wasn't supported anymore, hence this migration.

